### PR TITLE
support and replace data_manager's get_portal_catalog_map view

### DIFF
--- a/layers/models.py
+++ b/layers/models.py
@@ -455,6 +455,28 @@ class Theme(ChildType, SiteFlags):
         content_type = ContentType.objects.get_for_model(self.__class__)
         return ChildOrder.objects.filter(object_id=self.id, content_type=content_type)
 
+    # This property gets an array of all of the Layer records that are direct children of this Theme
+    # This is particularly used by the 'get_portal_catalog_map' view to identify 'visualizable' layers
+    # in the catalog.
+    @property
+    def layers(self):
+        content_type = ContentType.objects.get_for_model(Layer)
+        child_orders = ChildOrder.objects.filter(parent_theme=self, content_type=content_type).order_by('order', 'id')
+        layers = [child_order.content_object for child_order in child_orders]
+        return layers
+    
+    # This property gets an array of all of the Layer records that are decendats of this Theme
+    # This is particularly used by the 'get_portal_catalog_map' view to identify 'visualizable' layers in the catalog.
+    @property
+    def all_layers(self):
+        content_type = ContentType.objects.get_for_model(Theme)
+        child_theme_orders = ChildOrder.objects.filter(parent_theme=self, content_type=content_type).order_by('order', 'id')
+        layers = self.layers
+        for child_order in child_theme_orders:
+            if child_order.content_object.is_visible:
+                layers = layers + child_order.content_object.all_layers
+        return list(set(layers))
+
     # return dict formatted for use in bootstrap-3-typeahead 'layer search' widget in 'visualize'
     # overrides ChildType method to include any 'sublayer' information.
     def get_search_object(self, site_id, parent_theme):

--- a/layers/models.py
+++ b/layers/models.py
@@ -479,8 +479,14 @@ class Theme(ChildType, SiteFlags):
         for child_order in child_theme_orders:
             if child_order.content_object.is_visible:
                 layers = layers + child_order.content_object.all_layers
-        return list(set(layers))
 
+        unique_layers = []
+        seen_layer_pks = set()
+        for layer in layers:
+            if layer.pk not in seen_layer_pks:
+                seen_layer_pks.add(layer.pk)
+                unique_layers.append(layer)
+        return unique_layers
     # return dict formatted for use in bootstrap-3-typeahead 'layer search' widget in 'visualize'
     # overrides ChildType method to include any 'sublayer' information.
     def get_search_object(self, site_id, parent_theme):

--- a/layers/models.py
+++ b/layers/models.py
@@ -462,7 +462,11 @@ class Theme(ChildType, SiteFlags):
     def layers(self):
         content_type = ContentType.objects.get_for_model(Layer)
         child_orders = ChildOrder.objects.filter(parent_theme=self, content_type=content_type).order_by('order', 'id')
-        layers = [child_order.content_object for child_order in child_orders]
+        layers = [
+            child_order.content_object
+            for child_order in child_orders
+            if child_order.content_object.is_visible
+        ]
         return layers
     
     # This property gets an array of all of the Layer records that are decendats of this Theme

--- a/layers/tests/test_models.py
+++ b/layers/tests/test_models.py
@@ -991,13 +991,13 @@ class ThemeLayersPropertyTest(TestCase):
             order=4,
         )
         result = self.top_theme.all_layers
-        self.assertEqual(len(result), len(set(result)))
+        self.assertEqual(len(result), len(set(layer.pk for layer in result)))
 
     def test_all_layers_on_leaf_theme_equals_layers(self):
         # sub_theme has no sub-themes, so all_layers == layers
         self.assertEqual(
-            set(self.sub_theme.all_layers),
-            set(self.sub_theme.layers),
+            set(layer.pk for layer in self.sub_theme.all_layers),
+            set(layer.pk for layer in self.sub_theme.layers),
         )
 
 

--- a/layers/tests/test_models.py
+++ b/layers/tests/test_models.py
@@ -1,7 +1,9 @@
-from django.test import TestCase
+from django.test import TestCase, RequestFactory, override_settings
 from layers.models import Theme, Layer, MultilayerAssociation, MultilayerDimension, MultilayerDimensionValue, Companionship, LayerWMS, LayerArcREST, LayerArcFeatureService, LayerVector, LayerXYZ, ChildOrder
 from layers.serializers import ThemeSerializer, LayerWMSSerializer, CompanionLayerSerializer, LayerArcRESTSerializer, LayerArcFeatureServiceSerializer, LayerXYZSerializer, LayerVectorSerializer, SubThemeSerializer, ChildOrderSerializer
+from layers.views import get_portal_catalog_map
 from collections.abc import Collection
+import json
 from django.contrib.sites.models import Site
 from django.contrib.contenttypes.models import ContentType
 # request to get data from live site, mung it and make it into v2
@@ -863,4 +865,302 @@ class MultilayerTest(TestCase):
         self.assertEqual(False, january_data["is_multilayer_parent"])
         self.assertEqual([], january_data["dimensions"])
         self.assertEqual({}, january_data["associated_multilayers"])
+
+
+class ThemeLayersPropertyTest(TestCase):
+    """Tests for Theme.layers and Theme.all_layers model properties."""
+
+    def setUp(self):
+        self.site = Site.objects.get(pk=1)
+
+        self.top_theme = Theme.objects.create(
+            name="Top Theme",
+            is_top_theme=True,
+            is_visible=True,
+        )
+        self.top_theme.site.add(self.site)
+
+        self.sub_theme = Theme.objects.create(
+            name="Sub Theme",
+            is_visible=True,
+        )
+        self.sub_theme.site.add(self.site)
+
+        self.hidden_sub_theme = Theme.objects.create(
+            name="Hidden Sub Theme",
+            is_visible=False,
+        )
+        self.hidden_sub_theme.site.add(self.site)
+
+        self.direct_layer = Layer.objects.create(
+            name="Direct Layer",
+            layer_type="WMS",
+            catalog_name="direct-catalog",
+        )
+        self.direct_layer.site.add(self.site)
+
+        self.nested_layer = Layer.objects.create(
+            name="Nested Layer",
+            layer_type="WMS",
+            catalog_name="nested-catalog",
+        )
+        self.nested_layer.site.add(self.site)
+
+        self.hidden_nested_layer = Layer.objects.create(
+            name="Hidden Nested Layer",
+            layer_type="WMS",
+            catalog_name="hidden-nested-catalog",
+        )
+        self.hidden_nested_layer.site.add(self.site)
+
+        # top_theme -> direct_layer (direct child)
+        ChildOrder.objects.create(
+            parent_theme=self.top_theme,
+            content_object=self.direct_layer,
+            order=1,
+        )
+        # top_theme -> sub_theme -> nested_layer
+        ChildOrder.objects.create(
+            parent_theme=self.top_theme,
+            content_object=self.sub_theme,
+            order=2,
+        )
+        ChildOrder.objects.create(
+            parent_theme=self.sub_theme,
+            content_object=self.nested_layer,
+            order=1,
+        )
+        # top_theme -> hidden_sub_theme -> hidden_nested_layer
+        ChildOrder.objects.create(
+            parent_theme=self.top_theme,
+            content_object=self.hidden_sub_theme,
+            order=3,
+        )
+        ChildOrder.objects.create(
+            parent_theme=self.hidden_sub_theme,
+            content_object=self.hidden_nested_layer,
+            order=1,
+        )
+
+    def test_layers_returns_only_direct_layer_children(self):
+        result = self.top_theme.layers
+        self.assertIn(self.direct_layer, result)
+        self.assertNotIn(self.nested_layer, result)
+        self.assertNotIn(self.hidden_nested_layer, result)
+        self.assertNotIn(self.sub_theme, result)
+
+    def test_layers_returns_correct_count(self):
+        # Only direct_layer is a direct Layer child of top_theme
+        self.assertEqual(len(self.top_theme.layers), 1)
+
+    def test_layers_on_sub_theme(self):
+        result = self.sub_theme.layers
+        self.assertIn(self.nested_layer, result)
+        self.assertEqual(len(result), 1)
+
+    def test_layers_empty_when_no_direct_layer_children(self):
+        theme_no_layers = Theme.objects.create(name="No Layers Theme")
+        theme_no_layers.site.add(self.site)
+        ChildOrder.objects.create(
+            parent_theme=theme_no_layers,
+            content_object=self.sub_theme,
+            order=1,
+        )
+        self.assertEqual(theme_no_layers.layers, [])
+
+    def test_all_layers_includes_direct_and_nested(self):
+        result = self.top_theme.all_layers
+        self.assertIn(self.direct_layer, result)
+        self.assertIn(self.nested_layer, result)
+
+    def test_all_layers_excludes_layers_under_hidden_sub_theme(self):
+        # hidden_sub_theme has is_visible=False so its layers must not appear
+        result = self.top_theme.all_layers
+        self.assertNotIn(self.hidden_nested_layer, result)
+
+    def test_all_layers_contains_no_theme_objects(self):
+        result = self.top_theme.all_layers
+        for item in result:
+            self.assertIsInstance(item, Layer)
+
+    def test_all_layers_returns_unique_layers(self):
+        # Add nested_layer as a direct child too to create a duplicate
+        ChildOrder.objects.create(
+            parent_theme=self.top_theme,
+            content_object=self.nested_layer,
+            order=4,
+        )
+        result = self.top_theme.all_layers
+        self.assertEqual(len(result), len(set(result)))
+
+    def test_all_layers_on_leaf_theme_equals_layers(self):
+        # sub_theme has no sub-themes, so all_layers == layers
+        self.assertEqual(
+            set(self.sub_theme.all_layers),
+            set(self.sub_theme.layers),
+        )
+
+
+class GetPortalCatalogMapViewTest(TestCase):
+    """Tests for the get_portal_catalog_map view."""
+
+    def setUp(self):
+        self.site = Site.objects.get(pk=1)
+        self.factory = RequestFactory()
+
+        self.top_theme = Theme.objects.create(
+            name="Catalog Top Theme",
+            is_top_theme=True,
+            is_visible=True,
+        )
+        self.top_theme.site.add(self.site)
+
+        self.sub_theme = Theme.objects.create(
+            name="Catalog Sub Theme",
+            is_visible=True,
+        )
+        self.sub_theme.site.add(self.site)
+
+        self.layer_with_catalog_name = Layer.objects.create(
+            name="Mapped Layer",
+            layer_type="WMS",
+            catalog_name="my-catalog-record",
+        )
+        self.layer_with_catalog_name.site.add(self.site)
+
+        self.layer_no_catalog_name = Layer.objects.create(
+            name="Unmapped Layer",
+            layer_type="WMS",
+            catalog_name=None,
+        )
+        self.layer_no_catalog_name.site.add(self.site)
+
+        self.layer_empty_catalog_name = Layer.objects.create(
+            name="Empty Catalog Layer",
+            layer_type="WMS",
+            catalog_name="",
+        )
+        self.layer_empty_catalog_name.site.add(self.site)
+
+        self.nested_layer = Layer.objects.create(
+            name="Nested Catalog Layer",
+            layer_type="WMS",
+            catalog_name="nested-catalog-record",
+        )
+        self.nested_layer.site.add(self.site)
+
+        ChildOrder.objects.create(
+            parent_theme=self.top_theme,
+            content_object=self.layer_with_catalog_name,
+            order=1,
+        )
+        ChildOrder.objects.create(
+            parent_theme=self.top_theme,
+            content_object=self.layer_no_catalog_name,
+            order=2,
+        )
+        ChildOrder.objects.create(
+            parent_theme=self.top_theme,
+            content_object=self.layer_empty_catalog_name,
+            order=3,
+        )
+        ChildOrder.objects.create(
+            parent_theme=self.top_theme,
+            content_object=self.sub_theme,
+            order=4,
+        )
+        ChildOrder.objects.create(
+            parent_theme=self.sub_theme,
+            content_object=self.nested_layer,
+            order=1,
+        )
+
+    def _get(self):
+        request = self.factory.get("/layers/get_portal_catalog_map")
+        return get_portal_catalog_map(request)
+
+    @override_settings(CATALOG_TECHNOLOGY="GeoPortal2")
+    def test_returns_200(self):
+        response = self._get()
+        self.assertEqual(response.status_code, 200)
+
+    @override_settings(CATALOG_TECHNOLOGY="GeoPortal2")
+    def test_maps_catalog_name_to_layer_pk(self):
+        response = self._get()
+        data = json.loads(response.content)
+        self.assertIn("my-catalog-record", data)
+        self.assertEqual(data["my-catalog-record"], self.layer_with_catalog_name.pk)
+
+    @override_settings(CATALOG_TECHNOLOGY="GeoPortal2")
+    def test_includes_nested_layer_under_visible_sub_theme(self):
+        response = self._get()
+        data = json.loads(response.content)
+        self.assertIn("nested-catalog-record", data)
+        self.assertEqual(data["nested-catalog-record"], self.nested_layer.pk)
+
+    @override_settings(CATALOG_TECHNOLOGY="GeoPortal2")
+    def test_excludes_layers_without_catalog_name(self):
+        response = self._get()
+        data = json.loads(response.content)
+        # layer_no_catalog_name has catalog_name=None
+        for key in data:
+            self.assertNotEqual(data[key], self.layer_no_catalog_name.pk)
+
+    @override_settings(CATALOG_TECHNOLOGY="GeoPortal2")
+    def test_excludes_layers_with_empty_catalog_name(self):
+        response = self._get()
+        data = json.loads(response.content)
+        self.assertNotIn("", data)
+
+    @override_settings(CATALOG_TECHNOLOGY="GeoPortal2")
+    def test_excludes_layers_from_invisible_top_theme(self):
+        invisible_theme = Theme.objects.create(
+            name="Invisible Top Theme",
+            is_top_theme=True,
+            is_visible=False,
+        )
+        invisible_theme.site.add(self.site)
+        hidden_layer = Layer.objects.create(
+            name="Hidden Layer",
+            layer_type="WMS",
+            catalog_name="should-not-appear",
+        )
+        hidden_layer.site.add(self.site)
+        ChildOrder.objects.create(
+            parent_theme=invisible_theme,
+            content_object=hidden_layer,
+            order=1,
+        )
+        response = self._get()
+        data = json.loads(response.content)
+        self.assertNotIn("should-not-appear", data)
+
+    @override_settings(CATALOG_TECHNOLOGY="GeoPortal2")
+    def test_excludes_layers_from_non_top_level_theme(self):
+        orphan_theme = Theme.objects.create(
+            name="Orphan Theme",
+            is_top_theme=False,
+            is_visible=True,
+        )
+        orphan_theme.site.add(self.site)
+        orphan_layer = Layer.objects.create(
+            name="Orphan Layer",
+            layer_type="WMS",
+            catalog_name="orphan-catalog-record",
+        )
+        orphan_layer.site.add(self.site)
+        ChildOrder.objects.create(
+            parent_theme=orphan_theme,
+            content_object=orphan_layer,
+            order=1,
+        )
+        response = self._get()
+        data = json.loads(response.content)
+        self.assertNotIn("orphan-catalog-record", data)
+
+    @override_settings(CATALOG_TECHNOLOGY="NotGeoPortal2")
+    def test_returns_empty_dict_when_catalog_technology_not_geoportal2(self):
+        response = self._get()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content), {})
 

--- a/layers/urls.py
+++ b/layers/urls.py
@@ -18,6 +18,7 @@ urlpatterns = [
     re_path(r'^get_layer_catalog_content/(?P<objectType>\w+)/(?P<objectID>\d+)/(?P<themeID>\d+)/?$', views.get_layer_catalog_content),
     path('get_layer_catalog_content/<objectType>/<int:objectID>/', views.get_layer_catalog_content),
     re_path(r'^get_catalog_records/', views.get_catalog_records),
+    re_path(r'^get_portal_catalog_map', views.get_portal_catalog_map), # This allows the catalog page to link to 'visualize' layers
     re_path(r'^migration/layer_status/', views.layer_status),
     re_path(r'^migration/layer_details/', views.migration_layer_details),
     re_path(r'^picker/', views.get_picker),

--- a/layers/views.py
+++ b/layers/views.py
@@ -589,12 +589,15 @@ def get_catalog_records(request):
 def get_portal_catalog_map(request):
     data = {}
     if settings.CATALOG_TECHNOLOGY == "GeoPortal2":
-        viable_layers = []
+        seen_pks = set()
         for top_theme in Theme.objects.filter(is_top_theme=True).filter(is_visible=True):
-            viable_layers += [x for x in top_theme.all_layers if x.catalog_name not in ["", None]]
-        viable_layers = list(set(viable_layers))
-        for layer in viable_layers:
-            data[layer.catalog_name] = layer.pk
+            for layer in top_theme.all_layers:
+                if layer.catalog_name in ["", None]:
+                    continue
+                if layer.pk in seen_pks:
+                    continue
+                seen_pks.add(layer.pk)
+                data[layer.catalog_name] = layer.pk
     return JsonResponse(data)
 
 def get_sublayers_data(parent_theme):

--- a/layers/views.py
+++ b/layers/views.py
@@ -584,6 +584,19 @@ def get_catalog_records(request):
 
     return JsonResponse(data)
 
+# This allows the catalog page to link to 'visualize' layers, which requires knowing the layerID that corresponds to a 
+# given catalog record. Only layers with a catalog_name field will be included in this mapping.
+def get_portal_catalog_map(request):
+    data = {}
+    if settings.CATALOG_TECHNOLOGY == "GeoPortal2":
+        viable_layers = []
+        for top_theme in Theme.objects.filter(is_top_theme=True).filter(is_visible=True):
+            viable_layers += [x for x in top_theme.all_layers if x.catalog_name not in ["", None]]
+        viable_layers = list(set(viable_layers))
+        for layer in viable_layers:
+            data[layer.catalog_name] = layer.pk
+    return JsonResponse(data)
+
 def get_sublayers_data(parent_theme):
     sublayers_data = []
     sub_child_orders = ChildOrder.objects.filter(parent_theme=parent_theme).order_by('order')


### PR DESCRIPTION
This pull request introduces new functionality to map catalog records to visualizable layers, allowing the catalog page to link directly to layers in the application. It adds a new view, `get_portal_catalog_map`, and exposes it via the API. To support this, two new model properties, `layers` and `all_layers`, are added to the `Theme` model for retrieving direct and recursive child layers, respectively. Comprehensive tests are included to ensure correct behavior of these properties and the new API endpoint.

**New API and View:**

* Added the `get_portal_catalog_map` view in `layers/views.py`, which returns a mapping from catalog record names to corresponding layer primary keys for all visible, top-level themes and their visible descendant layers with a non-empty `catalog_name` (`[layers/views.pyR587-R599](diffhunk://#diff-8311850ef3defe8803e74dfe1ae642e0c15e7f054a9d90750639e294e720eec2R587-R599)`).
* Registered the new API endpoint in `layers/urls.py` to expose the mapping to the frontend (`[layers/urls.pyR21](diffhunk://#diff-70cfabda054792ce2008f441f4f081b7272fcf3706c132212d9f573d12afd019R21)`).

**Theme Model Enhancements:**

* Added the `layers` property to the `Theme` model to return all direct child `Layer` records (`[layers/models.pyR458-R479](diffhunk://#diff-fabef8bb4cc778662852e35020434ac3bb578730f6ab738278ff4139da688928R458-R479)`).
* Added the `all_layers` property to the `Theme` model to recursively return all visible descendant `Layer` records, excluding those under invisible sub-themes and ensuring uniqueness (`[layers/models.pyR458-R479](diffhunk://#diff-fabef8bb4cc778662852e35020434ac3bb578730f6ab738278ff4139da688928R458-R479)`).

**Testing:**

* Added comprehensive tests for the new `Theme.layers` and `Theme.all_layers` properties, as well as for the `get_portal_catalog_map` view, in `layers/tests/test_models.py` (`[layers/tests/test_models.pyR869-R1166](diffhunk://#diff-9cc77baf26d28cd37554f293ad90ff1b26ef87e0458641e9212ccbabeb0736c6R869-R1166)`).
* Updated test imports to support new tests and view usage (`[layers/tests/test_models.pyL1-R6](diffhunk://#diff-9cc77baf26d28cd37554f293ad90ff1b26ef87e0458641e9212ccbabeb0736c6L1-R6)`).