### PR TITLE
To1 pr01 fixture contract

### DIFF
--- a/layers/fixture_contract.py
+++ b/layers/fixture_contract.py
@@ -1,0 +1,176 @@
+from uuid import UUID
+
+
+FIXTURE_SCHEMA_VERSION = "layer-export-v2"
+
+NODE_MODEL_KEY = "model"
+NODE_SOURCE_PK_KEY = "source_pk"
+NODE_UUID_KEY = "uuid"
+NODE_FIELDS_KEY = "fields"
+NODE_RELATIONS_KEY = "relations"
+
+
+def normalize_uuid(value):
+    """Normalize UUID-like inputs to a canonical string-or-None value.
+
+    Use this whenever fixture code accepts mixed UUID sources
+    (UUID objects, strings, blank strings, or None).
+
+    Example:
+        normalize_uuid(UUID('12345678-1234-5678-1234-567812345678'))
+        -> '12345678-1234-5678-1234-567812345678'
+    """
+    if value is None:
+        return None
+    if isinstance(value, UUID):
+        return str(value)
+
+    normalized = str(value).strip()
+    if normalized == "":
+        return None
+    return normalized
+
+
+def build_ref(instance=None, model=None, source_pk=None, uuid_value=None):
+    """Build a canonical relationship reference object.
+
+    References are lightweight pointers used under relation fields
+    (for example, Layer -> AttributeInfo or Vector -> LookupInfo).
+
+    Example using an instance:
+        build_ref(instance=attribute_info)
+
+    Example using explicit values:
+        build_ref(model='layers.layer', source_pk=10, uuid_value='...')
+    """
+    if instance is not None:
+        model = instance._meta.label_lower
+        source_pk = instance.pk
+        uuid_value = getattr(instance, "uuid", None)
+
+    ref_obj = {
+        NODE_MODEL_KEY: model,
+        NODE_SOURCE_PK_KEY: source_pk,
+        NODE_UUID_KEY: normalize_uuid(uuid_value),
+    }
+    validate_ref_shape(ref_obj)
+    return ref_obj
+
+
+def build_node(model, source_pk, uuid_value, fields=None, relations=None):
+    """Build a canonical fixture node for one exported object.
+
+    Nodes are the top-level rows in the fixture and include the identity
+    metadata plus serialized fields and relationship refs.
+
+    Example:
+        build_node('layers.layer', 55, 'uuid-str', {'name': 'Layer A'}, {'attribute_fields': []})
+    """
+    node_obj = {
+        NODE_MODEL_KEY: model,
+        NODE_SOURCE_PK_KEY: source_pk,
+        NODE_UUID_KEY: normalize_uuid(uuid_value),
+        NODE_FIELDS_KEY: fields or {},
+        NODE_RELATIONS_KEY: relations or {},
+    }
+    validate_node_shape(node_obj)
+    return node_obj
+
+
+def validate_ref_shape(ref_obj):
+    """Validate that a reference object matches the expected contract.
+
+    Call this when ingesting untrusted fixture data or before writing refs
+    to ensure stable structure for downstream import logic.
+
+    Example:
+        validate_ref_shape({'model': 'layers.layer', 'source_pk': 1, 'uuid': '...'})
+    """
+    required_keys = {
+        NODE_MODEL_KEY,
+        NODE_SOURCE_PK_KEY,
+        NODE_UUID_KEY,
+    }
+    missing_keys = required_keys - set(ref_obj.keys())
+    if missing_keys:
+        raise ValueError("Invalid ref: missing keys {}".format(sorted(missing_keys)))
+
+    model = ref_obj[NODE_MODEL_KEY]
+    source_pk = ref_obj[NODE_SOURCE_PK_KEY]
+    uuid_value = ref_obj[NODE_UUID_KEY]
+
+    if not isinstance(model, str) or model.strip() == "":
+        raise ValueError("Invalid ref: 'model' must be a non-empty string")
+
+    if source_pk is not None and not isinstance(source_pk, int):
+        raise ValueError("Invalid ref: 'source_pk' must be an int or None")
+
+    if uuid_value is not None and not isinstance(uuid_value, str):
+        raise ValueError("Invalid ref: 'uuid' must be a string or None")
+
+
+def validate_node_shape(node_obj):
+    """Validate that a fixture node has required keys and value types.
+
+    This protects export and import code from malformed rows by ensuring
+    identity, fields, and relations all exist with expected types.
+
+    Example:
+        validate_node_shape({'model': 'layers.layer', 'source_pk': 1, 'uuid': '...', 'fields': {}, 'relations': {}})
+    """
+    required_keys = {
+        NODE_MODEL_KEY,
+        NODE_SOURCE_PK_KEY,
+        NODE_UUID_KEY,
+        NODE_FIELDS_KEY,
+        NODE_RELATIONS_KEY,
+    }
+    missing_keys = required_keys - set(node_obj.keys())
+    if missing_keys:
+        raise ValueError("Invalid node: missing keys {}".format(sorted(missing_keys)))
+
+    validate_ref_shape({
+        NODE_MODEL_KEY: node_obj[NODE_MODEL_KEY],
+        NODE_SOURCE_PK_KEY: node_obj[NODE_SOURCE_PK_KEY],
+        NODE_UUID_KEY: node_obj[NODE_UUID_KEY],
+    })
+
+    if not isinstance(node_obj[NODE_FIELDS_KEY], dict):
+        raise ValueError("Invalid node: 'fields' must be an object")
+
+    if not isinstance(node_obj[NODE_RELATIONS_KEY], dict):
+        raise ValueError("Invalid node: 'relations' must be an object")
+
+
+def ref_sort_key(ref_obj):
+    """Return a deterministic sorting key for reference objects.
+
+    Use this for stable export ordering so identical data emits identical
+    fixture output across runs.
+
+    Example:
+        sorted(refs, key=ref_sort_key)
+    """
+    validate_ref_shape(ref_obj)
+    return (
+        ref_obj[NODE_MODEL_KEY],
+        ref_obj[NODE_SOURCE_PK_KEY] if ref_obj[NODE_SOURCE_PK_KEY] is not None else -1,
+        ref_obj[NODE_UUID_KEY] if ref_obj[NODE_UUID_KEY] is not None else "",
+    )
+
+
+def node_sort_key(node_obj):
+    """Return a deterministic sorting key for fixture node objects.
+
+    Use this when producing normalized fixture output or comparing fixtures
+    in tests where ordering should be repeatable.
+
+    Example:
+        sorted(nodes, key=node_sort_key)
+    """
+    validate_node_shape(node_obj)
+    return (
+        node_obj[NODE_MODEL_KEY],
+        node_obj[NODE_SOURCE_PK_KEY] if node_obj[NODE_SOURCE_PK_KEY] is not None else -1,
+        node_obj[NODE_UUID_KEY] if node_obj[NODE_UUID_KEY] is not None else "",
+    )

--- a/layers/serializers.py
+++ b/layers/serializers.py
@@ -3,6 +3,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.forms.models import model_to_dict
 from django.template.loader import render_to_string
 from django.urls import reverse
+from layers.fixture_contract import build_node, build_ref
 from layers.models import Theme, Layer, ChildOrder, Companionship, LayerWMS, LayerArcREST, LayerArcFeatureService, LayerVector, LayerXYZ, AttributeInfo, LookupInfo
 from rest_framework import serializers
 #need to add catalog html to shared_layer_fields after adding it to subtheme serializer and to layer model
@@ -207,18 +208,17 @@ class LayerXYZExportSerializer(RasterTypeExportSerializer):
 
 class LayerExportFixtureSerializer(serializers.Serializer):
     def _to_ref(self, instance):
-        uuid_value = getattr(instance, 'uuid', None)
-        return {
-            'model': instance._meta.label_lower,
-            'source_pk': instance.pk,
-            'uuid': str(uuid_value) if uuid_value else None,
-        }
+        return build_ref(instance=instance)
 
     def _to_row(self, instance, fields, relations=None):
-        row = self._to_ref(instance)
-        row['fields'] = fields
-        row['relations'] = relations or {}
-        return row
+        uuid_value = getattr(instance, 'uuid', None)
+        return build_node(
+            model=instance._meta.label_lower,
+            source_pk=instance.pk,
+            uuid_value=uuid_value,
+            fields=fields,
+            relations=relations,
+        )
 
     def to_representation(self, instance):
         attribute_infos = list(instance.attribute_fields.all().order_by('order', 'display_name', 'pk'))

--- a/layers/tests/test_fixture_contract.py
+++ b/layers/tests/test_fixture_contract.py
@@ -1,0 +1,123 @@
+from uuid import uuid4
+
+from django.test import SimpleTestCase
+
+from layers.fixture_contract import (
+    build_node,
+    build_ref,
+    node_sort_key,
+    normalize_uuid,
+    ref_sort_key,
+    validate_node_shape,
+    validate_ref_shape,
+)
+
+
+class _Meta(object):
+    label_lower = "layers.layer"
+
+
+class _InstanceWithUUID(object):
+    _meta = _Meta()
+
+    def __init__(self):
+        self.pk = 42
+        self.uuid = uuid4()
+
+
+class _InstanceWithoutUUID(object):
+    _meta = _Meta()
+
+    def __init__(self):
+        self.pk = 84
+
+
+class FixtureContractTest(SimpleTestCase):
+    def test_normalize_uuid_returns_none_for_none(self):
+        self.assertIsNone(normalize_uuid(None))
+
+    def test_normalize_uuid_stringifies_uuid_instance(self):
+        value = uuid4()
+        self.assertEqual(normalize_uuid(value), str(value))
+
+    def test_build_ref_from_instance_with_uuid(self):
+        instance = _InstanceWithUUID()
+        ref_obj = build_ref(instance=instance)
+
+        self.assertEqual(ref_obj["model"], "layers.layer")
+        self.assertEqual(ref_obj["source_pk"], 42)
+        self.assertEqual(ref_obj["uuid"], str(instance.uuid))
+
+    def test_build_ref_from_instance_without_uuid(self):
+        instance = _InstanceWithoutUUID()
+        ref_obj = build_ref(instance=instance)
+
+        self.assertEqual(ref_obj["model"], "layers.layer")
+        self.assertEqual(ref_obj["source_pk"], 84)
+        self.assertIsNone(ref_obj["uuid"])
+
+    def test_build_node_defaults_fields_and_relations_to_empty_objects(self):
+        node_obj = build_node("layers.layer", 1, None)
+
+        self.assertEqual(node_obj["fields"], {})
+        self.assertEqual(node_obj["relations"], {})
+
+    def test_validate_ref_shape_accepts_valid_ref(self):
+        validate_ref_shape({
+            "model": "layers.layer",
+            "source_pk": 1,
+            "uuid": str(uuid4()),
+        })
+
+    def test_validate_ref_shape_rejects_missing_model(self):
+        with self.assertRaises(ValueError):
+            validate_ref_shape({
+                "source_pk": 1,
+                "uuid": str(uuid4()),
+            })
+
+    def test_validate_node_shape_accepts_valid_node(self):
+        validate_node_shape({
+            "model": "layers.layer",
+            "source_pk": 1,
+            "uuid": str(uuid4()),
+            "fields": {"name": "Layer"},
+            "relations": {},
+        })
+
+    def test_validate_node_shape_rejects_missing_relations(self):
+        with self.assertRaises(ValueError):
+            validate_node_shape({
+                "model": "layers.layer",
+                "source_pk": 1,
+                "uuid": str(uuid4()),
+                "fields": {},
+            })
+
+    def test_ref_sort_key_is_stable(self):
+        ref_one = {"model": "layers.lookupinfo", "source_pk": 2, "uuid": "b"}
+        ref_two = {"model": "layers.lookupinfo", "source_pk": 1, "uuid": "a"}
+
+        sorted_refs = sorted([ref_one, ref_two], key=ref_sort_key)
+
+        self.assertEqual(sorted_refs, [ref_two, ref_one])
+
+    def test_node_sort_key_is_stable(self):
+        node_one = {
+            "model": "layers.layer",
+            "source_pk": 2,
+            "uuid": "b",
+            "fields": {},
+            "relations": {},
+        }
+        node_two = {
+            "model": "layers.layer",
+            "source_pk": 1,
+            "uuid": "a",
+            "fields": {},
+            "relations": {},
+        }
+
+        sorted_nodes = sorted([node_one, node_two], key=node_sort_key)
+
+        self.assertEqual(sorted_nodes, [node_two, node_one])

--- a/layers/tests/test_fixture_contract.py
+++ b/layers/tests/test_fixture_contract.py
@@ -3,6 +3,11 @@ from uuid import uuid4
 from django.test import SimpleTestCase
 
 from layers.fixture_contract import (
+    NODE_FIELDS_KEY,
+    NODE_MODEL_KEY,
+    NODE_RELATIONS_KEY,
+    NODE_SOURCE_PK_KEY,
+    NODE_UUID_KEY,
     build_node,
     build_ref,
     node_sort_key,
@@ -44,59 +49,59 @@ class FixtureContractTest(SimpleTestCase):
         instance = _InstanceWithUUID()
         ref_obj = build_ref(instance=instance)
 
-        self.assertEqual(ref_obj["model"], "layers.layer")
-        self.assertEqual(ref_obj["source_pk"], 42)
-        self.assertEqual(ref_obj["uuid"], str(instance.uuid))
+        self.assertEqual(ref_obj[NODE_MODEL_KEY], "layers.layer")
+        self.assertEqual(ref_obj[NODE_SOURCE_PK_KEY], 42)
+        self.assertEqual(ref_obj[NODE_UUID_KEY], str(instance.uuid))
 
     def test_build_ref_from_instance_without_uuid(self):
         instance = _InstanceWithoutUUID()
         ref_obj = build_ref(instance=instance)
 
-        self.assertEqual(ref_obj["model"], "layers.layer")
-        self.assertEqual(ref_obj["source_pk"], 84)
-        self.assertIsNone(ref_obj["uuid"])
+        self.assertEqual(ref_obj[NODE_MODEL_KEY], "layers.layer")
+        self.assertEqual(ref_obj[NODE_SOURCE_PK_KEY], 84)
+        self.assertIsNone(ref_obj[NODE_UUID_KEY])
 
     def test_build_node_defaults_fields_and_relations_to_empty_objects(self):
         node_obj = build_node("layers.layer", 1, None)
 
-        self.assertEqual(node_obj["fields"], {})
-        self.assertEqual(node_obj["relations"], {})
+        self.assertEqual(node_obj[NODE_FIELDS_KEY], {})
+        self.assertEqual(node_obj[NODE_RELATIONS_KEY], {})
 
     def test_validate_ref_shape_accepts_valid_ref(self):
         validate_ref_shape({
-            "model": "layers.layer",
-            "source_pk": 1,
-            "uuid": str(uuid4()),
+            NODE_MODEL_KEY: "layers.layer",
+            NODE_SOURCE_PK_KEY: 1,
+            NODE_UUID_KEY: str(uuid4()),
         })
 
     def test_validate_ref_shape_rejects_missing_model(self):
         with self.assertRaises(ValueError):
             validate_ref_shape({
-                "source_pk": 1,
-                "uuid": str(uuid4()),
+                NODE_SOURCE_PK_KEY: 1,
+                NODE_UUID_KEY: str(uuid4()),
             })
 
     def test_validate_node_shape_accepts_valid_node(self):
         validate_node_shape({
-            "model": "layers.layer",
-            "source_pk": 1,
-            "uuid": str(uuid4()),
-            "fields": {"name": "Layer"},
-            "relations": {},
+            NODE_MODEL_KEY: "layers.layer",
+            NODE_SOURCE_PK_KEY: 1,
+            NODE_UUID_KEY: str(uuid4()),
+            NODE_FIELDS_KEY: {"name": "Layer"},
+            NODE_RELATIONS_KEY: {},
         })
 
     def test_validate_node_shape_rejects_missing_relations(self):
         with self.assertRaises(ValueError):
             validate_node_shape({
-                "model": "layers.layer",
-                "source_pk": 1,
-                "uuid": str(uuid4()),
-                "fields": {},
+                NODE_MODEL_KEY: "layers.layer",
+                NODE_SOURCE_PK_KEY: 1,
+                NODE_UUID_KEY: str(uuid4()),
+                NODE_FIELDS_KEY: {},
             })
 
     def test_ref_sort_key_is_stable(self):
-        ref_one = {"model": "layers.lookupinfo", "source_pk": 2, "uuid": "b"}
-        ref_two = {"model": "layers.lookupinfo", "source_pk": 1, "uuid": "a"}
+        ref_one = {NODE_MODEL_KEY: "layers.lookupinfo", NODE_SOURCE_PK_KEY: 2, NODE_UUID_KEY: "b"}
+        ref_two = {NODE_MODEL_KEY: "layers.lookupinfo", NODE_SOURCE_PK_KEY: 1, NODE_UUID_KEY: "a"}
 
         sorted_refs = sorted([ref_one, ref_two], key=ref_sort_key)
 
@@ -104,18 +109,18 @@ class FixtureContractTest(SimpleTestCase):
 
     def test_node_sort_key_is_stable(self):
         node_one = {
-            "model": "layers.layer",
-            "source_pk": 2,
-            "uuid": "b",
-            "fields": {},
-            "relations": {},
+            NODE_MODEL_KEY: "layers.layer",
+            NODE_SOURCE_PK_KEY: 2,
+            NODE_UUID_KEY: "b",
+            NODE_FIELDS_KEY: {},
+            NODE_RELATIONS_KEY: {},
         }
         node_two = {
-            "model": "layers.layer",
-            "source_pk": 1,
-            "uuid": "a",
-            "fields": {},
-            "relations": {},
+            NODE_MODEL_KEY: "layers.layer",
+            NODE_SOURCE_PK_KEY: 1,
+            NODE_UUID_KEY: "a",
+            NODE_FIELDS_KEY: {},
+            NODE_RELATIONS_KEY: {},
         }
 
         sorted_nodes = sorted([node_one, node_two], key=node_sort_key)

--- a/layers/tests/test_models.py
+++ b/layers/tests/test_models.py
@@ -8,6 +8,7 @@ from collections.abc import Collection
 import json
 from django.contrib.sites.models import Site
 from django.contrib.contenttypes.models import ContentType
+from layers.fixture_contract import NODE_FIELDS_KEY, NODE_MODEL_KEY, NODE_RELATIONS_KEY, NODE_SOURCE_PK_KEY, NODE_UUID_KEY
 from rest_framework import serializers
 # request to get data from live site, mung it and make it into v2
 class ThemeTest(TestCase):
@@ -404,9 +405,9 @@ class LayerExportFixtureSerializerTest(TestCase):
         )
         expected_attribute_refs = [
             {
-                'model': 'layers.attributeinfo',
-                'source_pk': x.pk,
-                'uuid': str(x.uuid),
+                NODE_MODEL_KEY: 'layers.attributeinfo',
+                NODE_SOURCE_PK_KEY: x.pk,
+                NODE_UUID_KEY: str(x.uuid),
             }
             for x in expected_attribute_infos_for_fixture
         ]
@@ -418,24 +419,24 @@ class LayerExportFixtureSerializerTest(TestCase):
             fixture_data[:-1],
             expected_attribute_infos_for_fixture,
         ):
-            self.assertEqual(fixture_row['model'], 'layers.attributeinfo')
-            self.assertEqual(fixture_row['source_pk'], expected_attribute_info.pk)
-            self.assertEqual(fixture_row['uuid'], str(expected_attribute_info.uuid))
+            self.assertEqual(fixture_row[NODE_MODEL_KEY], 'layers.attributeinfo')
+            self.assertEqual(fixture_row[NODE_SOURCE_PK_KEY], expected_attribute_info.pk)
+            self.assertEqual(fixture_row[NODE_UUID_KEY], str(expected_attribute_info.uuid))
             self.assertEqual(
-                fixture_row['fields'],
+                fixture_row[NODE_FIELDS_KEY],
                 AttributeInfoExportSerializer(expected_attribute_info).data,
             )
-            self.assertEqual(fixture_row['relations'], {})
+            self.assertEqual(fixture_row[NODE_RELATIONS_KEY], {})
 
         expected_layer_fields = dict(serializer_data)
         expected_layer_fields.pop('attribute_fields', None)
 
-        self.assertEqual(fixture_data[-1]['model'], 'layers.layer')
-        self.assertEqual(fixture_data[-1]['source_pk'], layer.pk)
-        self.assertEqual(fixture_data[-1]['uuid'], str(layer.uuid))
-        self.assertEqual(fixture_data[-1]['fields'], expected_layer_fields)
+        self.assertEqual(fixture_data[-1][NODE_MODEL_KEY], 'layers.layer')
+        self.assertEqual(fixture_data[-1][NODE_SOURCE_PK_KEY], layer.pk)
+        self.assertEqual(fixture_data[-1][NODE_UUID_KEY], str(layer.uuid))
+        self.assertEqual(fixture_data[-1][NODE_FIELDS_KEY], expected_layer_fields)
         self.assertEqual(
-            fixture_data[-1]['relations'],
+            fixture_data[-1][NODE_RELATIONS_KEY],
             {
                 'attribute_fields': expected_attribute_refs,
             },
@@ -461,37 +462,37 @@ class LayerExportFixtureSerializerTest(TestCase):
 
         expected_lookup_infos = sorted([lookup_a, lookup_b], key=lambda x: x.pk)
         for fixture_row, expected_lookup in zip(fixture_data[:2], expected_lookup_infos):
-            self.assertEqual(fixture_row['model'], 'layers.lookupinfo')
-            self.assertEqual(fixture_row['source_pk'], expected_lookup.pk)
-            self.assertEqual(fixture_row['uuid'], str(expected_lookup.uuid))
-            self.assertEqual(fixture_row['fields'], LookupInfoExportSerializer(expected_lookup).data)
-            self.assertEqual(fixture_row['relations'], {})
+            self.assertEqual(fixture_row[NODE_MODEL_KEY], 'layers.lookupinfo')
+            self.assertEqual(fixture_row[NODE_SOURCE_PK_KEY], expected_lookup.pk)
+            self.assertEqual(fixture_row[NODE_UUID_KEY], str(expected_lookup.uuid))
+            self.assertEqual(fixture_row[NODE_FIELDS_KEY], LookupInfoExportSerializer(expected_lookup).data)
+            self.assertEqual(fixture_row[NODE_RELATIONS_KEY], {})
 
         layer_row = fixture_data[2]
-        self.assertEqual(layer_row['model'], 'layers.layer')
-        self.assertEqual(layer_row['source_pk'], layer.pk)
-        self.assertEqual(layer_row['uuid'], str(layer.uuid))
-        self.assertEqual(layer_row['relations']['attribute_fields'], [])
+        self.assertEqual(layer_row[NODE_MODEL_KEY], 'layers.layer')
+        self.assertEqual(layer_row[NODE_SOURCE_PK_KEY], layer.pk)
+        self.assertEqual(layer_row[NODE_UUID_KEY], str(layer.uuid))
+        self.assertEqual(layer_row[NODE_RELATIONS_KEY]['attribute_fields'], [])
 
         vector_row = fixture_data[3]
-        self.assertEqual(vector_row['model'], 'layers.layervector')
-        self.assertEqual(vector_row['source_pk'], vector.pk)
-        self.assertIsNone(vector_row['uuid'])
+        self.assertEqual(vector_row[NODE_MODEL_KEY], 'layers.layervector')
+        self.assertEqual(vector_row[NODE_SOURCE_PK_KEY], vector.pk)
+        self.assertIsNone(vector_row[NODE_UUID_KEY])
         self.assertEqual(
-            vector_row['relations']['layer'],
+            vector_row[NODE_RELATIONS_KEY]['layer'],
             {
-                'model': 'layers.layer',
-                'source_pk': layer.pk,
-                'uuid': str(layer.uuid),
+                NODE_MODEL_KEY: 'layers.layer',
+                NODE_SOURCE_PK_KEY: layer.pk,
+                NODE_UUID_KEY: str(layer.uuid),
             },
         )
         self.assertEqual(
-            vector_row['relations']['lookup_table'],
+            vector_row[NODE_RELATIONS_KEY]['lookup_table'],
             [
                 {
-                    'model': 'layers.lookupinfo',
-                    'source_pk': lookup.pk,
-                    'uuid': str(lookup.uuid),
+                    NODE_MODEL_KEY: 'layers.lookupinfo',
+                    NODE_SOURCE_PK_KEY: lookup.pk,
+                    NODE_UUID_KEY: str(lookup.uuid),
                 }
                 for lookup in expected_lookup_infos
             ],


### PR DESCRIPTION
## PR 01 Goal
Establish one shared fixture contract and helper surface so all current and future export/import logic uses the same node and reference shapes.

## PR 01 Scope

Add a small shared contract module and utility functions.
Refactor current layer fixture export to use those helpers.
Add focused tests for contract normalization and deterministic output.
Do not change import behavior yet.
Do not add new relationship traversal yet.
## Files to touch now

serializers.py
test_models.py
## New files to add in PR 01

madrona-apps/mp-layers/layers/fixture_contract.py
madrona-apps/mp-layers/layers/tests/test_fixture_contract.py
## Exact implementation checklist

Create fixture contract constants in fixture_contract.py.
Add a function to normalize UUID values to string-or-none.
Add a function to build a canonical ref object.
Add a function to build a canonical node object.
Add a function to validate node shape for internal assertions/tests.
Add deterministic sort-key helpers for refs and nodes.
Update LayerExportFixtureSerializer in [serializers.py](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to call contract helpers instead of inline dict construction.
Keep serializer output schema exactly as today:
* model
* source_pk
* uuid
* fields
* relations
Ensure relations always exist as an object even when empty.
Ensure deterministic ordering remains stable.
Add new contract unit tests in test_fixture_contract.py.
Add or update one serializer-level integration test in [test_models.py](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to assert output still matches contract while using shared helpers.
## Function signatures to implement in fixture_contract.py

def normalize_uuid(value) -> str | None
def build_ref(instance=None, model=None, source_pk=None, uuid_value=None) -> dict
def build_node(model: str, source_pk: int | None, uuid_value: str | None, fields: dict | None = None, relations: dict | None = None) -> dict
def validate_ref_shape(ref_obj: dict) -> None
def validate_node_shape(node_obj: dict) -> None
def ref_sort_key(ref_obj: dict) -> tuple
def node_sort_key(node_obj: dict) -> tuple
## Expected behavior for each function

normalize_uuid:
* Returns None for None/empty input.
* Returns string form for UUID objects or strings.
build_ref:
* Supports instance input path and explicit args path.
* Emits only model, source_pk, uuid.
* uuid may be None.
build_node:
* Emits model, source_pk, uuid, fields, relations.
* fields defaults to empty object.
* relations defaults to empty object.
validate_ref_shape:
* Raises ValueError on missing keys or wrong types.
validate_node_shape:
* Raises ValueError on missing keys or wrong types.
ref_sort_key:
* Stable key using model, source_pk, uuid.
node_sort_key:
* Stable key using model, source_pk, uuid.
## Serializer refactor checklist in serializers.py

Import build_ref and build_node from fixture_contract.
Replace custom _to_ref implementation with build_ref.
Replace custom _to_row implementation with build_node.
Keep current logic for:
LookupInfo rows first when present.
AttributeInfo rows next.
Layer row next.
Specific instance row last.
Keep relation payload semantics unchanged.
Keep deterministic queryset order unchanged.
## Test cases to add in test_fixture_contract.py

test_normalize_uuid_returns_none_for_none
test_normalize_uuid_stringifies_uuid_instance
test_build_ref_from_instance_with_uuid
test_build_ref_from_instance_without_uuid
test_build_node_defaults_fields_and_relations_to_empty_objects
test_validate_ref_shape_accepts_valid_ref
test_validate_ref_shape_rejects_missing_model
test_validate_node_shape_accepts_valid_node
test_validate_node_shape_rejects_missing_relations
test_ref_sort_key_is_stable
test_node_sort_key_is_stable
## Test cases to add/update in test_models.py

test_layer_export_fixture_rows_match_contract_shape
For every row, assert required keys exist.
Assert fields is object.
Assert relations is object.
Assert uuid is string or None.
test_layer_export_fixture_order_is_deterministic
Same fixture generation twice yields same row order and content.
## PR 01 acceptance criteria

All existing layer fixture tests still pass after refactor.
New contract tests pass.
No changes to admin action behavior.
No changes to import behavior.
Output contract remains backward-compatible with current row schema.
## Out of scope for PR 01

Companion relationship export expansion.
Multilayer relationship export expansion.
Import planner and confirmation flow.
Multi-layer export action.