### PR TITLE
add companionship consideration to layer fixture export serializer

### DIFF
--- a/layers/serializers.py
+++ b/layers/serializers.py
@@ -210,6 +210,12 @@ class LayerExportFixtureSerializer(serializers.Serializer):
     def _to_ref(self, instance):
         return build_ref(instance=instance)
 
+    def _get_outgoing_companion_layers(self, companionship):
+        companion_layer_ids = companionship.companions.through.objects.filter(
+            companionship_id=companionship.pk,
+        ).values_list('layer_id', flat=True)
+        return list(Layer.all_objects.filter(pk__in=companion_layer_ids).order_by('pk'))
+
     def _to_row(self, instance, fields, relations=None):
         uuid_value = getattr(instance, 'uuid', None)
         return build_node(
@@ -221,65 +227,122 @@ class LayerExportFixtureSerializer(serializers.Serializer):
         )
 
     def to_representation(self, instance):
-        attribute_infos = list(instance.attribute_fields.all().order_by('order', 'display_name', 'pk'))
-        specific_instance = instance.specific_instance
-
-        lookup_infos = []
-        if specific_instance is not None and hasattr(specific_instance, 'lookup_table'):
-            lookup_infos = list(specific_instance.lookup_table.all().order_by('pk'))
-
+        # Export is built as a traversal pipeline so we can keep output
+        # deterministic while collecting related rows only once.
         fixture_rows = []
-        for lookup_info in lookup_infos:
-            fixture_rows.append(self._to_row(
-                lookup_info,
-                LookupInfoExportSerializer(lookup_info).data,
-            ))
+        seen_lookup_info_pks = set()
+        seen_attribute_info_pks = set()
+        seen_specific_instances = set()
+        seen_companionship_pks = set()
+        seen_layer_pks = set()
+        enqueued_layer_pks = {instance.pk}
+        layer_queue = [instance]
 
-        for attribute_info in attribute_infos:
-            fixture_rows.append(self._to_row(
-                attribute_info,
-                AttributeInfoExportSerializer(attribute_info).data,
-            ))
-
-        layer_fields = LayerExportSerializer(instance).data
-        layer_fields.pop('attribute_fields', None)
-        layer_relations = {
-            'attribute_fields': [self._to_ref(attribute_info) for attribute_info in attribute_infos],
+        specific_exporters = {
+            LayerWMS: LayerWMSExportSerializer,
+            LayerArcREST: LayerArcRESTExportSerializer,
+            LayerArcFeatureService: LayerArcFeatureServiceExportSerializer,
+            LayerVector: LayerVectorExportSerializer,
+            LayerXYZ: LayerXYZExportSerializer,
         }
 
-        fixture_rows.append(self._to_row(
-            instance,
-            layer_fields,
-            layer_relations,
-        ))
+        while layer_queue:
+            layer_obj = layer_queue.pop(0)
+            if layer_obj.pk in seen_layer_pks:
+                continue
+            seen_layer_pks.add(layer_obj.pk)
 
-        if specific_instance is not None:
-            specific_exporters = {
-                LayerWMS: LayerWMSExportSerializer,
-                LayerArcREST: LayerArcRESTExportSerializer,
-                LayerArcFeatureService: LayerArcFeatureServiceExportSerializer,
-                LayerVector: LayerVectorExportSerializer,
-                LayerXYZ: LayerXYZExportSerializer,
-            }
-
-            exporter_class = specific_exporters.get(type(specific_instance))
-            if exporter_class:
-                specific_data = dict(exporter_class(specific_instance).data)
-                specific_data.pop('layer', None)
-                specific_data.pop('lookup_table', None)
-
-                specific_relations = {
-                    'layer': self._to_ref(instance),
-                }
-
-                if hasattr(specific_instance, 'lookup_table'):
-                    specific_relations['lookup_table'] = [self._to_ref(lookup_info) for lookup_info in lookup_infos]
-
+            # Emit attribute rows before the owning layer row so downstream
+            # relation refs can point at a complete set of dependency rows.
+            attribute_infos = list(layer_obj.attribute_fields.all().order_by('order', 'display_name', 'pk'))
+            for attribute_info in attribute_infos:
+                if attribute_info.pk in seen_attribute_info_pks:
+                    continue
+                seen_attribute_info_pks.add(attribute_info.pk)
                 fixture_rows.append(self._to_row(
-                    specific_instance,
-                    specific_data,
-                    specific_relations,
+                    attribute_info,
+                    AttributeInfoExportSerializer(attribute_info).data,
                 ))
+
+            specific_instance = layer_obj.specific_instance
+            lookup_infos = []
+            if specific_instance is not None and hasattr(specific_instance, 'lookup_table'):
+                lookup_infos = list(specific_instance.lookup_table.all().order_by('pk'))
+
+            # Lookup rows are exported before the owning layer row for the same
+            # reason as attributes: the row graph stays self-contained.
+            for lookup_info in lookup_infos:
+                if lookup_info.pk in seen_lookup_info_pks:
+                    continue
+                seen_lookup_info_pks.add(lookup_info.pk)
+                fixture_rows.append(self._to_row(
+                    lookup_info,
+                    LookupInfoExportSerializer(lookup_info).data,
+                ))
+
+            outgoing_companionships = list(layer_obj.companionships.all().order_by('pk'))
+            layer_fields = LayerExportSerializer(layer_obj).data
+            layer_fields.pop('attribute_fields', None)
+            layer_relations = {
+                'attribute_fields': [self._to_ref(attribute_info) for attribute_info in attribute_infos],
+            }
+            if outgoing_companionships:
+                layer_relations['companionships'] = [self._to_ref(companionship) for companionship in outgoing_companionships]
+
+            # The base layer row carries refs to its attributes and outgoing
+            # companionships, but does not inline related objects.
+            fixture_rows.append(self._to_row(
+                layer_obj,
+                layer_fields,
+                layer_relations,
+            ))
+
+            # Specific layer-type rows are exported separately so the import
+            # side can rehydrate the polymorphic layer subtype independently.
+            if specific_instance is not None:
+                specific_key = (specific_instance._meta.label_lower, specific_instance.pk)
+                if specific_key not in seen_specific_instances:
+                    seen_specific_instances.add(specific_key)
+                    exporter_class = specific_exporters.get(type(specific_instance))
+                    if exporter_class:
+                        specific_data = dict(exporter_class(specific_instance).data)
+                        specific_data.pop('layer', None)
+                        specific_data.pop('lookup_table', None)
+
+                        specific_relations = {
+                            'layer': self._to_ref(layer_obj),
+                        }
+
+                        if hasattr(specific_instance, 'lookup_table'):
+                            specific_relations['lookup_table'] = [self._to_ref(lookup_info) for lookup_info in lookup_infos]
+
+                        fixture_rows.append(self._to_row(
+                            specific_instance,
+                            specific_data,
+                            specific_relations,
+                        ))
+
+            # Traverse companionships one-way: only follow outgoing links from
+            # the current layer, enqueue newly discovered companion layers, and
+            # export each companionship row once.
+            for companionship in outgoing_companionships:
+                companions = self._get_outgoing_companion_layers(companionship)
+                if companionship.pk not in seen_companionship_pks:
+                    seen_companionship_pks.add(companionship.pk)
+                    fixture_rows.append(self._to_row(
+                        companionship,
+                        {},
+                        {
+                            'layer': self._to_ref(companionship.layer),
+                            'companions': [self._to_ref(companion_layer) for companion_layer in companions],
+                        },
+                    ))
+
+                for companion_layer in companions:
+                    if companion_layer.pk in seen_layer_pks or companion_layer.pk in enqueued_layer_pks:
+                        continue
+                    enqueued_layer_pks.add(companion_layer.pk)
+                    layer_queue.append(companion_layer)
 
         return fixture_rows
 

--- a/layers/tests/test_fixture_companionship_export.py
+++ b/layers/tests/test_fixture_companionship_export.py
@@ -1,0 +1,111 @@
+from django.test import TestCase
+
+from layers.fixture_contract import (
+    NODE_MODEL_KEY,
+    NODE_RELATIONS_KEY,
+    NODE_SOURCE_PK_KEY,
+    NODE_UUID_KEY,
+)
+from layers.models import Companionship, Layer
+
+
+class LayerCompanionshipFixtureExportTest(TestCase):
+    def test_layer_export_fixture_includes_outgoing_companionship_and_companion_layers(self):
+        """Exported layer with 2 companions should include all three + the companionship row"""
+        root_layer = Layer.objects.create(name='Root Layer', layer_type='WMS')
+        companion_a = Layer.objects.create(name='Companion A', layer_type='WMS')
+        companion_b = Layer.objects.create(name='Companion B', layer_type='WMS')
+
+        companionship = Companionship.objects.create(layer=root_layer)
+        companionship.companions.set([companion_b, companion_a])
+
+        fixture_data = root_layer.to_export_dict()
+
+        companionship_rows = [
+            row for row in fixture_data
+            if row[NODE_MODEL_KEY] == 'layers.companionship' and row[NODE_SOURCE_PK_KEY] == companionship.pk
+        ]
+        self.assertEqual(len(companionship_rows), 1)
+
+        companionship_row = companionship_rows[0]
+        self.assertEqual(
+            companionship_row[NODE_RELATIONS_KEY]['layer'],
+            {
+                NODE_MODEL_KEY: 'layers.layer',
+                NODE_SOURCE_PK_KEY: root_layer.pk,
+                NODE_UUID_KEY: str(root_layer.uuid),
+            },
+        )
+
+        expected_companion_refs = [
+            {
+                NODE_MODEL_KEY: 'layers.layer',
+                NODE_SOURCE_PK_KEY: companion.pk,
+                NODE_UUID_KEY: str(companion.uuid),
+            }
+            for companion in sorted([companion_a, companion_b], key=lambda x: x.pk)
+        ]
+        self.assertEqual(companionship_row[NODE_RELATIONS_KEY]['companions'], expected_companion_refs)
+
+        exported_layer_pks = {
+            row[NODE_SOURCE_PK_KEY]
+            for row in fixture_data
+            if row[NODE_MODEL_KEY] == 'layers.layer'
+        }
+        self.assertIn(root_layer.pk, exported_layer_pks)
+        self.assertIn(companion_a.pk, exported_layer_pks)
+        self.assertIn(companion_b.pk, exported_layer_pks)
+
+    def test_layer_export_fixture_excludes_incoming_only_companionship(self):
+        """Test one-way companionship traversal: don't include layers that rely on
+        the exported layer as a companion, nor the companionship row itself."""
+        owner_layer = Layer.objects.create(name='Owner Layer', layer_type='WMS')
+        incoming_only_layer = Layer.objects.create(name='Incoming-only Layer', layer_type='WMS')
+
+        companionship = Companionship.objects.create(layer=owner_layer)
+        companionship.companions.add(incoming_only_layer)
+
+        fixture_data = incoming_only_layer.to_export_dict()
+
+        companionship_rows = [
+            row for row in fixture_data
+            if row[NODE_MODEL_KEY] == 'layers.companionship'
+        ]
+        self.assertEqual(companionship_rows, [])
+
+        exported_layer_pks = [
+            row[NODE_SOURCE_PK_KEY]
+            for row in fixture_data
+            if row[NODE_MODEL_KEY] == 'layers.layer'
+        ]
+        self.assertIn(incoming_only_layer.pk, exported_layer_pks)
+        self.assertNotIn(owner_layer.pk, exported_layer_pks)
+
+    def test_layer_export_fixture_includes_transitive_outgoing_companionship_chain(self):
+        """Exported layer with a companion that also has a companion should include
+        all three layers and both companionship rows."""
+        layer_a = Layer.objects.create(name='Layer A', layer_type='WMS')
+        layer_b = Layer.objects.create(name='Layer B', layer_type='WMS')
+        layer_c = Layer.objects.create(name='Layer C', layer_type='WMS')
+
+        companionship_ab = Companionship.objects.create(layer=layer_a)
+        companionship_ab.companions.add(layer_b)
+
+        companionship_bc = Companionship.objects.create(layer=layer_b)
+        companionship_bc.companions.add(layer_c)
+
+        fixture_data = layer_a.to_export_dict()
+
+        exported_layer_pks = {
+            row[NODE_SOURCE_PK_KEY]
+            for row in fixture_data
+            if row[NODE_MODEL_KEY] == 'layers.layer'
+        }
+        self.assertEqual(exported_layer_pks, {layer_a.pk, layer_b.pk, layer_c.pk})
+
+        exported_companionship_pks = {
+            row[NODE_SOURCE_PK_KEY]
+            for row in fixture_data
+            if row[NODE_MODEL_KEY] == 'layers.companionship'
+        }
+        self.assertEqual(exported_companionship_pks, {companionship_ab.pk, companionship_bc.pk})


### PR DESCRIPTION
# PR 03: Companion Layer Export Slice
## Scope:
* Extend Layer fixture export to include companion relationship data only.
* Include minimal related Layer refs required for later import remap.
* Do not yet include multilayer dimensions/associations/values.
## Touch points:
* serializers.py
* models.py
* test_models.py
## Pass criteria:
* Fixture includes companionship links with UUID-capable refs.
* Companion export is deduped and deterministic.
* Existing Layer fixture tests pass plus new companionship tests.
## Fail criteria:
* Companion links exported as id-only pointers.
* Companion traversal pulls unrelated layers beyond bounded scope.
